### PR TITLE
Change from Flask to FastAPI

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,7 +1,35 @@
-from flask import Flask
+from typing import Annotated
+from fastapi import FastAPI, status, Depends
+from fastapi.responses import JSONResponse
+from sqlmodel import SQLModel, Field, Session, create_engine
+from dotenv import dotenv_values
 
-app = Flask(__name__)
+# Load environment variables
+secrets = dotenv_values('.env.local')
 
+
+class User(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    username: str = Field(index=True)
+    password: str = Field()
+    access_level: str = Field()
+
+
+# Create SQLAlchemy database engine
+database_url = secrets['NEON_DATABASE_URL']
+engine = create_engine(database_url)
+
+
+def create_db_and_tables():
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    with Session(engine) as session:
+        yield session
+
+
+SessionDep = Annotated[Session, Depends(get_session)]
 
 # Create FastAPI instance
 app = FastAPI()

--- a/api/index.py
+++ b/api/index.py
@@ -3,9 +3,15 @@ from flask import Flask
 app = Flask(__name__)
 
 
-@app.route('/api/hello', methods=['GET'])
-def hello():
-    return {'message': 'Hello, World!'}
+# Create FastAPI instance
+app = FastAPI()
 
-if __name__ == '__main__':
-    app.run(port=5328)
+
+@app.on_event('startup')
+def on_startup():
+    create_db_and_tables()
+
+
+@app.get('/api/hello')
+def hello():
+    return JSONResponse(status_code=status.HTTP_200_OK, content={'message': 'Hello, World!'})

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: '/api/:path*',
-        destination: process.env.NODE_ENV === 'development' ? 'http://127.0.0.1:5328/api/:path*' : '/api/',
+        destination: process.env.NODE_ENV === 'development' ? 'http://127.0.0.1:8000/api/:path*' : '/api/',
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "flask-dev": "pip install -r requirements.txt && python -m flask --app api/index run -p 5328",
+    "fastapi-dev": "pip install -r requirements.txt && python -m uvicorn api.index:app --reload",
     "next-dev": "next dev",
-    "dev": "concurrently \"npm run next-dev\" \"npm run flask-dev\"",
+    "dev": "concurrently \"npm run next-dev\" \"npm run fastapi-dev\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
-Flask==3.1.0
+fastapi==0.115.5
+uvicorn[standard]==0.32.1
+bcrypt==4.2.1
+sqlmodel==0.0.22
+python-dotenv==1.0.1
+psycopg2-binary==2.9.10


### PR DESCRIPTION
# Flask to FastAPI
Changed to FastAPI for a more lightweight integration having less unused features of the framework in comparison

### index.py
- Initialized FastAPI instead of Flask
- Change /api/hello endpoint response
- Get environment variables
- Create User model
- Create database engine
- Create database and tables on startup

### next.config.ts
- Changed port to 8000

### package.json
- Renamed flask-dev to fastapi-dev
- Using uvicorn

### requirements.txt
- Removed Flask
- Added FastAPI
- Added uvicorn
- Added bcrypt
- Added SQLModel
- Added python-dotenv
- Added psycopg2-binary